### PR TITLE
Fixed bug where the timer font color was still red after running down…

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -248,6 +248,7 @@ function resetGame() {
 }
 
 function startTimer(duration, display) {
+  $("#timerText").css("color", "lightgreen");
   let timer = duration, minutes, seconds;
   intervalID = setInterval(function() {
     minutes = parseInt(timer / 60, 10);


### PR DESCRIPTION
… to zero and then clicking the reset button to try again. Done by setting default timer font color at the top of the startTimer function.